### PR TITLE
Compare differences in string

### DIFF
--- a/cmd_diff.go
+++ b/cmd_diff.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/urfave/cli/v2"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type DiffOption struct {
@@ -137,7 +138,12 @@ destVariableLoop:
 
 	// add or update attributes defined in srcVariable
 	for _, v := range srcVariable.vars {
-		w.Body().SetAttributeValue(v.Key, CtyValue(v.Value))
+		ctyValue := CtyValue(v.Value)
+		if IsPrimitive(ctyValue) {
+			w.Body().SetAttributeValue(v.Key, cty.StringVal(v.Value))
+		} else {
+			w.Body().SetAttributeValue(v.Key, ctyValue)
+		}
 	}
 
 	return fileDiff(string(w.Bytes()), destText.BuildHCLFileString())

--- a/cmd_diff_test.go
+++ b/cmd_diff_test.go
@@ -219,8 +219,8 @@ func TestCmdDiff(t *testing.T) {
 					AnyTimes()
 			},
 			expect: `  environment        = "test"
-  port               = 3000
-  terraform          = true
+  port               = "3000"
+  terraform          = "true"
   availability_zones = ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]
 - delete1            = "value1"
 - delete2            = "value2"

--- a/testdata/mixedtypes.tfvars
+++ b/testdata/mixedtypes.tfvars
@@ -1,6 +1,6 @@
 environment        = "test"
-port               = 3000
-terraform          = true
+port               = "3000"
+terraform          = "true"
 availability_zones = ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]
 tags = {
   repo = "github.com/thaim/tfcvars"

--- a/testdata/withcomment.tfvars
+++ b/testdata/withcomment.tfvars
@@ -1,5 +1,5 @@
 # env
 environment = "test"
 # port
-port      = 3000
-terraform = true
+port      = "3000"
+terraform = "true"


### PR DESCRIPTION
## Problems
When comparing the differences between local variables and Terraform Cloud variables using the diff command, local variables were compared using primitive types, while Terraform Cloud variables were compared using string types.
When comparing the differences between local variables and Terraform Cloud variables using the push command, both local variables and Terraform Cloud variables were compared using string types.

Differing comparison methods between the diff command and the push command need to be resolved.

## Changes
Treat local variables as string types in the diff command.

resolves: #102 