### PR TITLE
Change defautl behavior for overwrite to be true

### DIFF
--- a/cmd_pull.go
+++ b/cmd_pull.go
@@ -25,7 +25,7 @@ func NewPullOption(c *cli.Context) *PullOption {
 	var opt = &PullOption{}
 
 	opt.varFile = c.String("var-file")
-	opt.overwrite = c.Bool("overwrite") && !c.Bool("merge")
+	opt.overwrite = !c.Bool("merge")
 	opt.prevVarfile = nil
 	opt.includeEnv = c.Bool("include-env")
 	opt.includeVariableSet = c.Bool("include-variable-set")

--- a/cmd_pull_test.go
+++ b/cmd_pull_test.go
@@ -340,7 +340,7 @@ func TestNewPullOption(t *testing.T) {
 			args: []string{},
 			expect: &PullOption{
 				varFile:     "terraform.tfvars",
-				overwrite:   false,
+				overwrite:   true,
 				prevVarfile: nil,
 			},
 		},
@@ -349,7 +349,7 @@ func TestNewPullOption(t *testing.T) {
 			args: []string{"--var-file", "custom.tfvars"},
 			expect: &PullOption{
 				varFile:     "custom.tfvars",
-				overwrite:   false,
+				overwrite:   true,
 				prevVarfile: nil,
 			},
 		},
@@ -359,6 +359,15 @@ func TestNewPullOption(t *testing.T) {
 			expect: &PullOption{
 				varFile:     "terraform.tfvars",
 				overwrite:   true,
+				prevVarfile: nil,
+			},
+		},
+		{
+			name: "enable merge option",
+			args: []string{"--merge"},
+			expect: &PullOption{
+				varFile:     "terraform.tfvars",
+				overwrite:   false,
 				prevVarfile: nil,
 			},
 		},
@@ -376,7 +385,7 @@ func TestNewPullOption(t *testing.T) {
 			args: []string{"--include-env"},
 			expect: &PullOption{
 				varFile:    "terraform.tfvars",
-				overwrite:  false,
+				overwrite:  true,
 				includeEnv: true,
 			},
 		},
@@ -385,7 +394,7 @@ func TestNewPullOption(t *testing.T) {
 			args: []string{"--include-variable-set"},
 			expect: &PullOption{
 				varFile:            "terraform.tfvars",
-				overwrite:          false,
+				overwrite:          true,
 				includeVariableSet: true,
 			},
 		},


### PR DESCRIPTION
If --merge option is not specified, pull command act as overwrite mode.
if --merge option is specified, pull command act as merge mode.
if both --overwrite and --merge option is specified, pull command act as merge mode. This means --overwrite mode is not used.